### PR TITLE
DTX-714, DTX-715 Add an endpoint to return all page names and number of form submission for each of them

### DIFF
--- a/ao-api/app/app.go
+++ b/ao-api/app/app.go
@@ -416,6 +416,7 @@ func routing(db *db.DB, queue queueService.QueueService, redisClient *redis.Clie
 	uibuilder.POST("/project/:project_tag/page", middlewares.TokenTypeMiddleware([]string{"user"}), uibuilderController.UpsertPage())
 	uibuilder.DELETE("/project/:project_tag/page/:page_name", middlewares.TokenTypeMiddleware([]string{"user"}), uibuilderController.DeletePage())
 	uibuilder.GET("/project/:project_tag/page", middlewares.TokenTypeMiddleware([]string{"user"}), uibuilderController.ListPages())
+	uibuilder.GET("/project/:project_tag/page/form/list", middlewares.TokenTypeMiddleware([]string{"user"}), uibuilderController.ListPagesWithMoreDetails(uiFormService))
 	uibuilder.GET("/project/:project_tag/page/:page_name", middlewares.TokenTypeMiddleware([]string{"user"}), uibuilderController.GetPage())
 	uibuilder.POST("/project/:project_tag/page/:page_name/publish", middlewares.TokenTypeMiddleware([]string{"user"}), uibuilderController.PublishPage())
 	uibuilder.POST("/project/:project_tag/page/:page_name/preview", middlewares.TokenTypeMiddleware([]string{"user"}), uibuilderController.PreviewPage())

--- a/ao-api/controllers/uibuilder/get_page.go
+++ b/ao-api/controllers/uibuilder/get_page.go
@@ -3,6 +3,7 @@ package uibuilder
 import (
 	"net/http"
 
+	"github.com/dotenx/dotenx/ao-api/pkg/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -20,6 +21,12 @@ func (controller *UIbuilderController) GetPage() gin.HandlerFunc {
 		page, err := controller.Service.GetPage(accountId, projectTag, pageName)
 		if err != nil {
 			logrus.Error(err.Error())
+			if err == utils.ErrPageNotFound {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"message": err.Error(),
+				})
+				return
+			}
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}

--- a/ao-api/controllers/uibuilder/list_pages_with_more_details.go
+++ b/ao-api/controllers/uibuilder/list_pages_with_more_details.go
@@ -1,0 +1,43 @@
+package uibuilder
+
+import (
+	"net/http"
+
+	"github.com/dotenx/dotenx/ao-api/services/uiFormService"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+func (controller *UIbuilderController) ListPagesWithMoreDetails(uiFormService uiFormService.UIFormService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		var accountId string
+		if a, ok := c.Get("accountId"); ok {
+			accountId = a.(string)
+		}
+
+		projectTag := c.Param("project_tag")
+		pages, err := controller.Service.ListPages(accountId, projectTag)
+		if err != nil {
+			logrus.Error(err.Error())
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+
+		resp := make([]map[string]interface{}, 0)
+		for _, pageName := range pages {
+			submittedForms, err := uiFormService.GetNumberOfFormSubmission(projectTag, pageName)
+			if err != nil {
+				logrus.Error(err.Error())
+				c.AbortWithStatus(http.StatusInternalServerError)
+				return
+			}
+			resp = append(resp, map[string]interface{}{
+				"page_name":       pageName,
+				"submitted_forms": submittedForms,
+			})
+		}
+
+		c.JSON(http.StatusOK, resp)
+	}
+}

--- a/ao-api/pkg/utils/utils.go
+++ b/ao-api/pkg/utils/utils.go
@@ -33,6 +33,7 @@ var ErrUserDatabaseNotFound = errors.New("database not found. this error occurs 
 var ErrDatabaseJobResultAlreadyExists = errors.New("database job result already exists")
 var ErrDatabaseJobIsPending = errors.New("datbase job status is pending")
 var ErrIntegrationNotFound = errors.New("integration not found")
+var ErrPageNotFound = errors.New("page not found")
 
 // constants
 const ForgetPasswordUseCase = "forget_password" // for security_code table (user management)

--- a/ao-api/services/uiFormService/get_number_of_form_submission.go
+++ b/ao-api/services/uiFormService/get_number_of_form_submission.go
@@ -1,0 +1,5 @@
+package uiFormService
+
+func (uf *uiFormService) GetNumberOfFormSubmission(projectTag, pageName string) (int64, error) {
+	return uf.Store.GetNumberOfFormSubmission(noContext, projectTag, pageName)
+}

--- a/ao-api/services/uiFormService/interface.go
+++ b/ao-api/services/uiFormService/interface.go
@@ -14,6 +14,7 @@ func NewUIFormService(store uiFormStore.UIFormStore) UIFormService {
 type UIFormService interface {
 	AddNewResponse(form models.UIForm) error
 	GetUiPageResponseList(projectTag, pageName string) ([]models.UIForm, error)
+	GetNumberOfFormSubmission(projectTag, pageName string) (int64, error)
 }
 
 type uiFormService struct {

--- a/ao-api/stores/uiFormStore/get_number_of_form_submission.go
+++ b/ao-api/stores/uiFormStore/get_number_of_form_submission.go
@@ -20,7 +20,7 @@ func (store *uiFormStore) GetNumberOfFormSubmission(ctx context.Context, project
 		return -1, fmt.Errorf("driver not supported")
 	}
 	var num int64
-	err := store.db.Connection.Select(&num, stmt, projectTag, pageName)
+	err := store.db.Connection.QueryRow(stmt, projectTag, pageName).Scan(&num)
 	if err != nil {
 		logrus.Error(err.Error())
 		return -1, err

--- a/ao-api/stores/uiFormStore/get_number_of_form_submission.go
+++ b/ao-api/stores/uiFormStore/get_number_of_form_submission.go
@@ -1,0 +1,29 @@
+package uiFormStore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dotenx/dotenx/ao-api/db"
+	"github.com/sirupsen/logrus"
+)
+
+func (store *uiFormStore) GetNumberOfFormSubmission(ctx context.Context, projectTag, pageName string) (int64, error) {
+	numberOfSubmission := `
+	SELECT count(*) FROM ui_forms WHERE project_tag = $1 AND page_name = $2;
+	`
+	var stmt string
+	switch store.db.Driver {
+	case db.Postgres:
+		stmt = numberOfSubmission
+	default:
+		return -1, fmt.Errorf("driver not supported")
+	}
+	var num int64
+	err := store.db.Connection.Select(&num, stmt, projectTag, pageName)
+	if err != nil {
+		logrus.Error(err.Error())
+		return -1, err
+	}
+	return num, nil
+}

--- a/ao-api/stores/uiFormStore/store.go
+++ b/ao-api/stores/uiFormStore/store.go
@@ -14,6 +14,7 @@ func New(db *db.DB) UIFormStore {
 type UIFormStore interface {
 	AddNewResponse(ctx context.Context, form models.UIForm) error
 	GetUiPageResponseList(ctx context.Context, projectTag, pageName string) ([]models.UIForm, error)
+	GetNumberOfFormSubmission(ctx context.Context, projectTag, pageName string) (int64, error)
 }
 
 type uiFormStore struct {

--- a/ao-api/stores/uibuilderStore/get_page.go
+++ b/ao-api/stores/uibuilderStore/get_page.go
@@ -3,11 +3,11 @@ package uibuilderStore
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/dotenx/dotenx/ao-api/db"
 	"github.com/dotenx/dotenx/ao-api/models"
+	"github.com/dotenx/dotenx/ao-api/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +28,7 @@ func (store *uibuilderStore) GetPage(ctx context.Context, accountId, projectTag,
 	if err != nil {
 		logrus.Error(err)
 		if err == sql.ErrNoRows {
-			err = errors.New("page not found")
+			err = utils.ErrPageNotFound
 		}
 	}
 	return page, err


### PR DESCRIPTION
DTX-714: Back-end should return 400 or 404 instead of 500 as status code when page or its url isn't exist
DTX-715: Add an endpoint to return all page names and number of form submission for each of them